### PR TITLE
Adding a hint, where to get information for troubleshooting

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,4 @@ To run it, type
 
 and navigate to [http://localhost:5001/](http://localhost:5001/). The initial credentials are admin : password .
 
+For Troubleshooting have a look at [the Wiki of adhocrace.hhu_theme](https://github.com/hhucn/adhocracy.hhu_theme/wiki)


### PR DESCRIPTION
- I added a sentence at the end of README.md to give a hint where to get some information, that may help in case of troubleshooting.
- Specialy the recommendation is to go to Wiki. So we don't have to change the hhu_theme repo every time we want add some troubleshooting information.
