### PR TITLE
Added an option to edit (add or remove) tags

### DIFF
--- a/adhocracy_client/templates/tag/tiles.html
+++ b/adhocracy_client/templates/tag/tiles.html
@@ -40,10 +40,10 @@
     <div class="only-js" id="add_tags"> 
         <a href="#" class="showhide_button button_small" 
            data-target="#tags_form">
-            ${_("add tags...")}
+            ${_("edit tags...")}
         </a>
     </div>
-    <div class="close" id="tags_form" data-cancel=".cancel">
+    <div id="tags_form" data-cancel=".cancel">
         <form action="${h.base_url('/tag', delegateable.instance)}" method="POST">
             ${h.field_token()|n}
             <input name="delegateable" type="hidden" value="${delegateable.id}" />
@@ -54,7 +54,22 @@
             <div class="submit">        
                 <input type="submit" value="${_('Add tags')}" />
                 <a href="#" class="cancel">${_('Cancel')}</a>
-                </div>
+            </div><br>
+            <h6>${_("Remove tags")}</h6>
+            <div id="tags_form">
+                <p>
+                    %if len(delegateable.tags):
+                    ${", ".join([h.tag.link_with_untag(tag, delegateable, simple=True) for 
+                                (tag, count) in delegateable.tags])|n}
+                    %else:
+                    ${_('No tags to remove')}
+                    %endif
+                </p>
+            </div>
+            <script>
+                $('div[id=tags_form]').hide();
+                $('div[id=add_tags]').click(function() { $('div[id=tags_form]').show();});
+            </script>
         </form>
     </div>
     %endif


### PR DESCRIPTION
I make this pull request because I think an option to remove tags should be included as fast as possible to production use. Furthermore the former "add tags" dialog has been improved and changed to "edit tags". A "stackoverflow.com"-textbox like edit tags functionality will be added later as discussed with phihag. 
